### PR TITLE
fix(integration-tests): Fix test issues with Spring Boot 2.4 upgrade

### DIFF
--- a/kayenta-integration-tests/kayenta-integration-tests.gradle
+++ b/kayenta-integration-tests/kayenta-integration-tests.gradle
@@ -5,9 +5,9 @@ dependencies {
     testImplementation "org.awaitility:awaitility:4.0.3"
     testImplementation "io.micrometer:micrometer-registry-prometheus"
     testImplementation "io.micrometer:micrometer-registry-graphite"
-    testImplementation "org.springframework.cloud:spring-cloud-starter:2.1.2.RELEASE" // needed for bootstrap phase when all embedded containers are setup
-    testImplementation "com.playtika.testcontainers:embedded-redis:1.89"
-    testImplementation "com.playtika.testcontainers:embedded-minio:1.89"
+    testImplementation "org.springframework.cloud:spring-cloud-starter-bootstrap" // needed for bootstrap phase when all embedded containers are setup
+    testImplementation "com.playtika.testcontainers:embedded-redis:2.2.11"
+    testImplementation "com.playtika.testcontainers:embedded-minio:2.2.11"
     testImplementation "org.testcontainers:testcontainers"
 }
 

--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/BaseIntegrationTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/BaseIntegrationTest.java
@@ -19,10 +19,12 @@ import com.netflix.kayenta.Main;
 import com.netflix.kayenta.configuration.MetricsReportingConfiguration;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.actuate.metrics.AutoConfigureMetrics;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+@AutoConfigureMetrics
 @SpringBootTest(
     classes = {MetricsReportingConfiguration.class, Main.class},
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,

--- a/kayenta-integration-tests/src/test/resources/application-base.yml
+++ b/kayenta-integration-tests/src/test/resources/application-base.yml
@@ -34,6 +34,11 @@ server:
 
 # Does it make sense to publish all Kayenta metrics to all datasources in integraion tests?
 spring:
+  cloud:
+    discovery:
+      client:
+        composite-indicator:
+          enabled: false
   autoconfigure:
     exclude: >
       org.springframework.boot.actuate.autoconfigure.metrics.web.tomcat.TomcatMetricsAutoConfiguration,


### PR DESCRIPTION
* Add `@AutoConfigureMetrics`. `@SpringBootTest` no longer configures available monitoring systems and only provide the in-memory MeterRegistry. If you were exporting metrics as part of an integration test, you can add `@AutoConfigureMetrics` to your test to restore the previous behaviour. https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes
* Upgrade embedded testcontainers. `testcontainers-spring-boot` project migrated to Spring Boot 2.4 in 2.0.0 version. In order to use this project with Spring Boot 2.4, you need to use `spring-cloud-starter-bootstrap` dependency. https://github.com/PlaytikaOSS/testcontainers-spring-boot#how-to-use
* Disable composite indicator to avoid cast problems with `OrcaCompositeHealthContributor.status()` after moving to `spring-cloud-starter-bootstrap`.